### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<url>git@github.com:jangasoft/hook.git</url>
 	</scm>
 	<properties>
-		<commons-collections-version>3.2.1</commons-collections-version>
+		<commons-collections-version>3.2.2</commons-collections-version>
 		<commons-lang-version>3.1</commons-lang-version>
 		<junit-version>4.11</junit-version>
 		<guava-version>16.0.1</guava-version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/